### PR TITLE
Added two new "field" types: has and scope. This grants the ability t…

### DIFF
--- a/src/ArrayBuilder.php
+++ b/src/ArrayBuilder.php
@@ -46,6 +46,14 @@ class ArrayBuilder
             $this->buildWheres($query, $arrayQuery['where']);
         }
 
+        if (isset($arrayQuery['has'])) {
+            $this->buildHas($query, $arrayQuery['has']);
+        }
+
+        if (isset($arrayQuery['scope'])) {
+            $this->buildScope($query, $arrayQuery['scope']);
+        }
+
         if (isset($arrayQuery['fields'])) {
             $this->buildFields($query, $arrayQuery['fields']);
         }
@@ -364,6 +372,32 @@ class ArrayBuilder
     protected function buildHaving($queryBuilder, $havingField, $havingOperator, $havingValue, $boolean)
     {
         $queryBuilder->having($havingField, $havingOperator, $havingValue, $boolean);
+    }
+
+    /**
+     * @param $queryBuilder
+     * @param $relationships
+     */
+    protected function buildHas($queryBuilder, $relationships)
+    {
+        if (is_array($relationships))
+            foreach ($relationships as $relationship)
+                $queryBuilder->has($relationship);
+        else
+            $queryBuilder->has($relationships);
+    }
+
+    /**
+     * @param $queryBuilder
+     * @param $scopes
+     */
+    protected function buildScope($queryBuilder, $scopes)
+    {
+        if (is_array($scopes))
+            foreach ($scopes as $scope)
+                $queryBuilder->$scope();
+        else
+            $queryBuilder->$scopes();
     }
 
     /**


### PR DESCRIPTION
Added two new "field" types: has and scope. This grants the ability to query the eloquent model with the has(<relationship>) and/or to add a model scope. 

Usage: 

Eloquent:
```phpPost::hotAndPopular()->get();```

With arrayQuery:  
```phpPost::arrayQuery([ "scope" => "hotAndPopular" ])->get();```

You can even add N scopes like that:
```phpPost::arrayQuery([ "scope" => ["whatsNew", "hotAndPopular"] ])->get();```

Same goes to query relationship existence:

Eloquent:
```phpPost::has("comments")->get();```

With arrayQuery:  
```phpPost::arrayQuery([ "has" => "comments" ])->get();```

You can also add N relationships like that:
```phpPost::arrayQuery([ "has" => ["comments", "author"] ])->get();```